### PR TITLE
Add xdelta3.so handling to --dir

### DIFF
--- a/Linux/Program.cs
+++ b/Linux/Program.cs
@@ -55,8 +55,16 @@ namespace Linux
 
                     if (!File.Exists(Path.Combine(specific.GetDownloadFolder(), "xdelta3.so")))
                     {
-                        Console.WriteLine("Extracting xdelta3");
-                        WriteResourceToFile("Linux.Costura32.xdelta3.so", Path.Combine(specific.GetDownloadFolder(), "xdelta3.so"));
+                        try
+                        {
+                            Console.WriteLine("Extracting xdelta3");
+                            WriteResourceToFile("Linux.Costura32.xdelta3.so", Path.Combine(specific.GetDownloadFolder(), "xdelta3.so"));
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine("Error writing xdelta3.so: " + ex.Message);
+                            Environment.Exit(1);
+                        }
                     }
 
                     int tries = 0;

--- a/Linux/Program.cs
+++ b/Linux/Program.cs
@@ -29,18 +29,18 @@ namespace Linux
 
             return false;
         }
-        
+
         public static void WriteResourceToFile(string resourceName, string fileName)
         {
-            using(var resource = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
+            using (var resource = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
             {
-                using(var file = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+                using (var file = new FileStream(fileName, FileMode.Create, FileAccess.Write))
                 {
                     resource.CopyTo(file);
-                } 
+                }
             }
         }
-        
+
         public static void Main(string[] args)
         {
             using (SentrySdk.Init("https://76dcf1f2484f4839a78b3713420b5147@o462013.ingest.sentry.io/5556322"))
@@ -65,15 +65,15 @@ namespace Linux
                         if (!FilesLocked(specific))
                         {
                             new Main(specific);
-                            
+
                             while (true)
                                 Thread.Sleep(1000);
-                            
+
                             return;
                         }
                         Thread.Sleep(1000 * tries);
                     }
-                    
+
                     specific.Exit();
                 }
             }

--- a/Linux/Program.cs
+++ b/Linux/Program.cs
@@ -51,13 +51,14 @@ namespace Linux
 
                     Console.WriteLine("CML Linux");
 
-                    if (!File.Exists("xdelta3.so"))
+                    var specific = new LinuxSpecific(args);
+
+                    if (!File.Exists(Path.Combine(specific.GetDownloadFolder(), "xdelta3.so")))
                     {
                         Console.WriteLine("Extracting xdelta3");
-                        WriteResourceToFile("Linux.Costura32.xdelta3.so", "xdelta3.so");
+                        WriteResourceToFile("Linux.Costura32.xdelta3.so", Path.Combine(specific.GetDownloadFolder(), "xdelta3.so"));
                     }
 
-                    var specific = new LinuxSpecific(args);
                     int tries = 0;
                     while (tries++ < 3)
                     {

--- a/Linux/Program.cs
+++ b/Linux/Program.cs
@@ -53,12 +53,14 @@ namespace Linux
 
                     var specific = new LinuxSpecific(args);
 
-                    if (!File.Exists(Path.Combine(specific.GetDownloadFolder(), "xdelta3.so")))
+                    var xdelta3Path = Path.Combine(specific.GetDownloadFolder(), "xdelta3.so");
+
+                    if (!File.Exists(xdelta3Path))
                     {
                         try
                         {
                             Console.WriteLine("Extracting xdelta3");
-                            WriteResourceToFile("Linux.Costura32.xdelta3.so", Path.Combine(specific.GetDownloadFolder(), "xdelta3.so"));
+                            WriteResourceToFile("Linux.Costura32.xdelta3.so", xdelta3Path);
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
Resolves #5 

Adds handling of the xdelta3.so file to the --dir argument (using the same GetDownloadFolder as #4) to allow running CMLauncher in read-only directories

(Also minor formatting to stop the "helpful suggestions" from Zed)