### PR TITLE
Validate ETags for CDN downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# JetBrains Rider files
+.idea/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/Shared/EtagValidatingStream.cs
+++ b/Shared/EtagValidatingStream.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+
+public class EtagValidatingStream : Stream
+{
+    
+    public override bool CanRead => true;
+    public override bool CanWrite => false;
+    public override bool CanSeek => false;
+    public override long Length => _source.Length;
+    public override long Position
+    {
+        get => _source.Position;
+        set => throw new NotSupportedException();
+    }
+    
+    private readonly Stream _source;
+    private readonly EtagValidation _validation;
+    private readonly EtagValidation.IDigest _digest;
+    private readonly string _etag;
+    
+    public EtagValidatingStream(Stream src, EtagValidation validation, string etag)
+    {
+        _source = src;
+        _validation = validation;
+        _digest = validation.NewDigest();
+        _etag = etag;
+    }
+    
+    //
+    
+    public override void Flush()
+    {
+        _source.Flush();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (count == 0) return 0;
+        int c = _source.Read(buffer, offset, count);
+        if (c == 0)
+        {
+            bool ok = _validation.Check(_etag, _digest);
+            if (!ok) throw new IOException("checksum failed (etag: " + _etag + ")");
+            return 0;
+        }
+        _digest.Update(buffer, offset, c);
+        return c;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+    
+}

--- a/Shared/EtagValidatingStream.cs
+++ b/Shared/EtagValidatingStream.cs
@@ -27,8 +27,6 @@ public class EtagValidatingStream : Stream
         _etag = etag;
     }
     
-    //
-    
     public override void Flush()
     {
         _source.Flush();

--- a/Shared/EtagValidation.cs
+++ b/Shared/EtagValidation.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Security.Cryptography;
+
+/**
+ * Scheme to handle ETag header
+ * validation for HTTP transfers
+ */
+public abstract class EtagValidation
+{
+
+    public static readonly EtagValidation None = new NullImpl();
+    public static readonly EtagValidation HexMd5 = new Md5HexImpl();
+    
+    //
+    
+    public abstract IDigest NewDigest();
+
+    public abstract bool Check(string etag, IDigest hash);
+    
+    //
+    
+    public interface IDigest : IDisposable
+    {
+        void Update(byte[] buffer, int offset, int count);
+    }
+    
+    private class NullImpl : EtagValidation
+    {
+        
+        public override IDigest NewDigest()
+        {
+            return new Digest();
+        }
+
+        public override bool Check(string etag, IDigest hash)
+        {
+            return true;
+        }
+        
+        //
+
+        private class Digest : IDigest
+        {
+            
+            public void Update(byte[] buffer, int offset, int count)
+            {
+                // NO-OP
+            }
+
+            public void Dispose()
+            {
+                // NO-OP
+            }
+            
+        }
+        
+    }
+    
+    private class Md5HexImpl : EtagValidation
+    {
+        
+        public override IDigest NewDigest()
+        {
+            return new Digest();
+        }
+
+        public override bool Check(string etag, IDigest hash)
+        {
+            etag = etag.Trim('"');
+            if (etag.Length != 32) return false;
+            if (hash is not Digest) return false;
+            byte[] a = ((Digest) hash).Complete();
+            byte[] b;
+            try { b = Convert.FromHexString(etag); } catch (FormatException) { return false; }
+            return CryptographicOperations.FixedTimeEquals(a, b);
+        }
+        
+        //
+        
+        private class Digest : IDigest
+        {
+
+            public readonly MD5 Hash;
+
+            public Digest()
+            {
+                Hash = MD5.Create();
+            }
+            
+            //
+
+            public void Update(byte[] buffer, int offset, int count)
+            {
+                Hash.TransformBlock(buffer, offset, count, null, 0);
+            }
+
+            public byte[] Complete()
+            {
+                Hash.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                return Hash.Hash;
+            }
+
+            public void Dispose()
+            { 
+                Hash.Dispose();
+            }
+            
+        }
+        
+    }
+    
+}

--- a/Shared/EtagValidation.cs
+++ b/Shared/EtagValidation.cs
@@ -24,12 +24,12 @@ public abstract class EtagValidation
         void Update(byte[] buffer, int offset, int count);
     }
     
-    private class NullImpl : EtagValidation
+    private class NullImpl : EtagValidation, IDigest
     {
         
         public override IDigest NewDigest()
         {
-            return new Digest();
+            return this;
         }
 
         public override bool Check(string etag, IDigest hash)
@@ -37,21 +37,14 @@ public abstract class EtagValidation
             return true;
         }
         
-        //
-
-        private class Digest : IDigest
+        public void Update(byte[] buffer, int offset, int count)
         {
-            
-            public void Update(byte[] buffer, int offset, int count)
-            {
-                // NO-OP
-            }
+            // NO-OP
+        }
 
-            public void Dispose()
-            {
-                // NO-OP
-            }
-            
+        public void Dispose()
+        {
+            // NO-OP
         }
         
     }
@@ -80,29 +73,29 @@ public abstract class EtagValidation
         private class Digest : IDigest
         {
 
-            public readonly MD5 Hash;
+            private readonly MD5 _hash;
 
             public Digest()
             {
-                Hash = MD5.Create();
+                _hash = MD5.Create();
             }
             
             //
 
             public void Update(byte[] buffer, int offset, int count)
             {
-                Hash.TransformBlock(buffer, offset, count, null, 0);
+                _hash.TransformBlock(buffer, offset, count, null, 0);
             }
 
             public byte[] Complete()
             {
-                Hash.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-                return Hash.Hash;
+                _hash.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                return _hash.Hash;
             }
 
             public void Dispose()
             { 
-                Hash.Dispose();
+                _hash.Dispose();
             }
             
         }

--- a/Shared/EtagValidation.cs
+++ b/Shared/EtagValidation.cs
@@ -11,13 +11,11 @@ public abstract class EtagValidation
     public static readonly EtagValidation None = new NullImpl();
     public static readonly EtagValidation HexMd5 = new Md5HexImpl();
     
-    //
     
     public abstract IDigest NewDigest();
 
     public abstract bool Check(string etag, IDigest hash);
     
-    //
     
     public interface IDigest : IDisposable
     {
@@ -68,8 +66,6 @@ public abstract class EtagValidation
             return CryptographicOperations.FixedTimeEquals(a, b);
         }
         
-        //
-        
         private class Digest : IDigest
         {
 
@@ -79,8 +75,6 @@ public abstract class EtagValidation
             {
                 _hash = MD5.Create();
             }
-            
-            //
 
             public void Update(byte[] buffer, int offset, int count)
             {

--- a/Shared/HttpClientExtensions.cs
+++ b/Shared/HttpClientExtensions.cs
@@ -16,10 +16,10 @@ public static class HttpClientExtensions
     public static async Task DownloadAsync(
         this HttpClient client, 
         string requestUri, 
-        Stream destination, 
+        Stream destination,
+        EtagValidation etagValidation,
         IProgress<float> progress = null,
-        CancellationToken cancellationToken = default,
-        EtagValidation etagValidation = null)
+        CancellationToken cancellationToken = default)
     {
         // Get the http headers first to examine the content length
         using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
@@ -30,7 +30,7 @@ public static class HttpClientExtensions
             using (var download = await response.Content.ReadAsStreamAsync())
             {
                 // Reroute download stream for etag validation
-                Stream source = etag != null && etagValidation != null && !etag.IsWeak && etag.Tag.Length != 0 ?
+                Stream source = etag != null && !etag.IsWeak && etag.Tag.Length != 0 ?
                         new EtagValidatingStream(download, etagValidation, etag.Tag) : download;
 
                 // Ignore progress reporting when no progress reporter was 

--- a/Shared/HttpClientExtensions.cs
+++ b/Shared/HttpClientExtensions.cs
@@ -13,28 +13,38 @@ public static class HttpClientExtensions
         return client;
     }
 
-    public static async Task DownloadAsync(this HttpClient client, string requestUri, Stream destination, IProgress<float> progress = null, CancellationToken cancellationToken = default)
+    public static async Task DownloadAsync(
+        this HttpClient client, 
+        string requestUri, 
+        Stream destination, 
+        IProgress<float> progress = null,
+        CancellationToken cancellationToken = default,
+        EtagValidation etagValidation = null)
     {
         // Get the http headers first to examine the content length
         using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
         {
             var contentLength = response.Content.Headers.ContentLength;
+            var etag = response.Headers.ETag;
 
             using (var download = await response.Content.ReadAsStreamAsync())
             {
+                // Reroute download stream for etag validation
+                Stream source = etag != null && etagValidation != null && !etag.IsWeak && etag.Tag.Length != 0 ?
+                        new EtagValidatingStream(download, etagValidation, etag.Tag) : download;
 
                 // Ignore progress reporting when no progress reporter was 
                 // passed or when the content length is unknown
                 if (progress == null || !contentLength.HasValue)
                 {
-                    await download.CopyToAsync(destination);
+                    await source.CopyToAsync(destination);
                     return;
                 }
 
                 // Convert absolute progress (bytes downloaded) into relative progress (0% - 100%)
                 var relativeProgress = new Progress<long>(totalBytes => progress.Report((float)totalBytes / contentLength.Value));
                 // Use extension method to report progress while downloading
-                await download.CopyToAsync(destination, 81920, relativeProgress, cancellationToken);
+                await source.CopyToAsync(destination, 81920, relativeProgress, cancellationToken);
                 progress.Report(1);
             }
         }

--- a/Shared/Main.cs
+++ b/Shared/Main.cs
@@ -237,7 +237,7 @@ public class Main : IProgress<float>
             {
                 using (var file = new FileStream(tmp.Path, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
-                    await client.DownloadAsync(downloadUrl, file, this, etagValidation: etag);
+                    await client.DownloadAsync(downloadUrl, file, etag, this);
                 }
             }
 
@@ -298,7 +298,7 @@ public class Main : IProgress<float>
             {
                 using (var file = new FileStream(tmp.Path, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
-                    await client.DownloadAsync(downloadUrl, file, this, etagValidation: etag);
+                    await client.DownloadAsync(downloadUrl, file, etag, this);
                 }
             }
 

--- a/Shared/Main.cs
+++ b/Shared/Main.cs
@@ -227,6 +227,7 @@ public class Main : IProgress<float>
     private async Task<int> UpdateUsingZip(int version)
     {
         platformSpecific.UpdateLabel("Downloading update...");
+        var etag = platformSpecific.UseCDN() ? EtagValidation.HexMd5 : EtagValidation.None;
         string downloadUrl = platformSpecific.UseCDN() ? $"{cdnUrl}/{platformSpecific.GetCDNPrefix()}{version}/{platformSpecific.GetCDNFilename()}" :
             $"https://jenkins.kirkstall.top-cat.me/job/ChroMapper/{version}/artifact/{platformSpecific.GetJenkinsFilename()}";
 
@@ -236,7 +237,7 @@ public class Main : IProgress<float>
             {
                 using (var file = new FileStream(tmp.Path, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
-                    await client.DownloadAsync(downloadUrl, file, this);
+                    await client.DownloadAsync(downloadUrl, file, this, etagValidation: etag);
                 }
             }
 
@@ -288,6 +289,7 @@ public class Main : IProgress<float>
     private async Task<int> UpdateUsingPatch(int source, int dest)
     {
         platformSpecific.UpdateLabel($"Downloading patch for {dest}");
+        var etag = platformSpecific.UseCDN() ? EtagValidation.HexMd5 : EtagValidation.None;
         string downloadUrl = $"{cdnUrl}/{platformSpecific.GetCDNPrefix()}{dest}/{source}.patch";
 
         using (var tmp = new TempFile())
@@ -296,7 +298,7 @@ public class Main : IProgress<float>
             {
                 using (var file = new FileStream(tmp.Path, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
-                    await client.DownloadAsync(downloadUrl, file, this);
+                    await client.DownloadAsync(downloadUrl, file, this, etagValidation: etag);
                 }
             }
 

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)EtagValidation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TempFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Channel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Config.cs" />
@@ -20,5 +21,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)StreamExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BinaryPatchUtility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpdateManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)EtagValidatingStream.cs" />
   </ItemGroup>
 </Project>

--- a/Shared/UpdateManager.cs
+++ b/Shared/UpdateManager.cs
@@ -38,7 +38,7 @@ public class UpdateManager
             {
                 using (var file = new FileStream(tmp.Path, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
-                    await client.DownloadAsync($"{Config.CDN_URL}/{platform.GetCMLFilename()}", file);
+                    await client.DownloadAsync($"{Config.CDN_URL}/{platform.GetCMLFilename()}", file, etagValidation: EtagValidation.HexMd5);
                 }
             }
 

--- a/Shared/UpdateManager.cs
+++ b/Shared/UpdateManager.cs
@@ -38,7 +38,7 @@ public class UpdateManager
             {
                 using (var file = new FileStream(tmp.Path, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
-                    await client.DownloadAsync($"{Config.CDN_URL}/{platform.GetCMLFilename()}", file, etagValidation: EtagValidation.HexMd5);
+                    await client.DownloadAsync($"{Config.CDN_URL}/{platform.GetCMLFilename()}", file, EtagValidation.HexMd5);
                 }
             }
 


### PR DESCRIPTION
Will resolve #9. Uses the ``ETag`` header reported by the CDN, assuming it is an MD5 hash, to validate downloaded files and guard against in-flight corruption. 

If you are curious what the value of the ``ETag`` header is for any given CDN endpoint, keep in mind that ``HEAD`` requests are not handled properly (results in 404), however a ``Range: bytes=0-0`` request header on a normal ``GET`` *is* respected. Full example with curl:
```text
> curl -s -D /dev/stderr -H "range: bytes=0-0" https://cm.topc.at/nix/892/Linux.tar.gz 2>&1 >/dev/null | grep -oP '(?<=etag:\s")[\da-f]{32}(?=")'
b22969aaed7b6f9ab3cb94b58baba491
> curl -s https://cm.topc.at/nix/892/Linux.tar.gz | md5sum - | grep -oP '^[\da-f]{32}'
b22969aaed7b6f9ab3cb94b58baba491
```

Some possible due diligence to do:

- [ ] Investigate error handling strategies. Currently a hash mismatch throws which presents as a silent failure to most users, maybe we can get an error message box?
- [x] Ensure that the ``ETag`` header is reliable and will remain that way.
- [x] Ensure that this approach does not conflict with future backend plans (stronger hashes, signatures, etc.)
